### PR TITLE
Fix `toggle_product_monitoring` and `get_products` API call

### DIFF
--- a/patrowlhears4py/api.py
+++ b/patrowlhears4py/api.py
@@ -61,7 +61,7 @@ class PatrowlHearsApi:
         try:
             r = requests.Request(
                 method=method.upper(),
-                url=self.url+url,
+                url=self.url + url,
                 data=data,
                 params=params,
                 headers={
@@ -85,7 +85,7 @@ class PatrowlHearsApi:
         params = "?page={}&limit={}".format(page, limit)
 
         try:
-            return self.rs.get(self.url+"/api/orgs/{}".format(params)).json()
+            return self.rs.get(self.url + "/api/orgs/{}".format(params)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to list orgs: {}".format(e))
 
@@ -97,7 +97,7 @@ class PatrowlHearsApi:
         :rtype: json
         """
         try:
-            return self.rs.get(self.url+"/api/vulns/latest").json()
+            return self.rs.get(self.url + "/api/vulns/latest").json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to retrieve vuln: {}".format(e))
 
@@ -108,7 +108,7 @@ class PatrowlHearsApi:
         :rtype: json
         """
         try:
-            return self.rs.get(self.url+"/api/vulns/stats").json()
+            return self.rs.get(self.url + "/api/vulns/stats").json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to retrieve vuln stats: {}".format(e))
 
@@ -144,7 +144,7 @@ class PatrowlHearsApi:
             filters += "&cpe={}".format(str(cpe).lower())
 
         try:
-            return self.rs.get(self.url+"/api/vulns/{}".format(filters)).json()
+            return self.rs.get(self.url + "/api/vulns/{}".format(filters)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to retrieve vuln: {}".format(e))
 
@@ -228,7 +228,7 @@ class PatrowlHearsApi:
                 data.update({'references': vuln['references']})
 
         try:
-            return self.rs.post(self.url+"/api/vulns/add", json=data).json()
+            return self.rs.post(self.url + "/api/vulns/add", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to add vuln: {}".format(e))
 
@@ -240,7 +240,7 @@ class PatrowlHearsApi:
         :rtype: json
         """
         try:
-            return self.rs.get(self.url+"/api/vulns/{}".format(vuln_id)).json()
+            return self.rs.get(self.url + "/api/vulns/{}".format(vuln_id)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to retrieve vuln: {}".format(e))
 
@@ -252,7 +252,7 @@ class PatrowlHearsApi:
         :rtype: json
         """
         try:
-            return self.rs.get(self.url+"/api/vulns/{}/exploits".format(vuln_id)).json()
+            return self.rs.get(self.url + "/api/vulns/{}/exploits".format(vuln_id)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to retrieve vuln exploits: {}".format(e))
 
@@ -278,7 +278,7 @@ class PatrowlHearsApi:
         :rtype: json
         """
         try:
-            return self.rs.get(self.url+"/api/vulns/{}/threats".format(vuln_id)).json()
+            return self.rs.get(self.url + "/api/vulns/{}/threats".format(vuln_id)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to retrieve vuln threats: {}".format(e))
 
@@ -290,7 +290,7 @@ class PatrowlHearsApi:
         :rtype: json
         """
         try:
-            return self.rs.get(self.url+"/api/vulns/{}/history".format(vuln_id)).json()
+            return self.rs.get(self.url + "/api/vulns/{}/history".format(vuln_id)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to get vuln history: {}".format(e))
 
@@ -309,7 +309,7 @@ class PatrowlHearsApi:
             'vendor_name': vendor_name
         }
         try:
-            return self.rs.post(self.url+"/api/monitor/vendor/toggle", json=data).json()
+            return self.rs.post(self.url + "/api/monitor/vendor/toggle", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to toggle vendor monitoring status: {}".format(e))
 
@@ -331,7 +331,7 @@ class PatrowlHearsApi:
             'product_name': product_name
         }
         try:
-            return self.rs.post(self.url+"/api/monitor/product/toggle", json=data).json()
+            return self.rs.post(self.url + "/api/monitor/product/toggle", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to toggle product monitoring status: {}".format(e))
 
@@ -350,7 +350,7 @@ class PatrowlHearsApi:
             'package_id': package_id
         }
         try:
-            return self.rs.post(self.url+"/api/monitor/package/toggle", json=data).json()
+            return self.rs.post(self.url + "/api/monitor/package/toggle", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to toggle vendor monitoring status: {}".format(e))
 
@@ -369,7 +369,7 @@ class PatrowlHearsApi:
             'vuln_id': vuln_id
         }
         try:
-            return self.rs.post(self.url+"/api/vulns/{}/toggle".format(vuln_id), json=data).json()
+            return self.rs.post(self.url + "/api/vulns/{}/toggle".format(vuln_id), json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to toggle vuln monitoring status: {}".format(e))
 
@@ -381,7 +381,7 @@ class PatrowlHearsApi:
         :rtype: json
         """
         try:
-            return self.rs.get(self.url+"/api/vulns/{}/refresh_score".format(vuln_id)).json()
+            return self.rs.get(self.url + "/api/vulns/{}/refresh_score".format(vuln_id)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to refresh vuln score: {}".format(e))
 
@@ -393,7 +393,7 @@ class PatrowlHearsApi:
         :param to: Search data to date (format: YYYY-MM-DD). Optional.
         :rtype: json
         """
-        url = self.url+"/api/data/export/info?"
+        url = self.url + "/api/data/export/info?"
         if since is not None:
             url = "{}&since={}".format(url, since)
         if to is not None:
@@ -412,7 +412,7 @@ class PatrowlHearsApi:
         :param limit: Limit rows per table. Optional.
         :rtype: json
         """
-        url = self.url+"/api/data/export/full?"
+        url = self.url + "/api/data/export/full?"
         if since is not None:
             url = "{}&since={}".format(url, since)
         if to is not None:
@@ -465,7 +465,7 @@ class PatrowlHearsApi:
                 data.update({'maturity': exploit['maturity']})
 
         try:
-            return self.rs.post(self.url+"/api/data/submit", json=data).json()
+            return self.rs.post(self.url + "/api/data/submit", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to retrieve data: {}".format(e))
 
@@ -478,7 +478,7 @@ class PatrowlHearsApi:
         :rtype: json
         """
         try:
-            return self.rs.get(self.url+"/api/vulns/{}/exploits/{}/del".format(vuln_id, exploit_id)).json()
+            return self.rs.get(self.url + "/api/vulns/{}/exploits/{}/del".format(vuln_id, exploit_id)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to delete exploit: {}".format(e))
 
@@ -500,7 +500,7 @@ class PatrowlHearsApi:
             params += "&monitored=true"
 
         try:
-            return self.rs.get(self.url+"/api/kb/vendors/{}".format(params)).json()
+            return self.rs.get(self.url + "/api/kb/vendors/{}".format(params)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to list vendors: {}".format(e))
 
@@ -524,7 +524,7 @@ class PatrowlHearsApi:
             params += "&monitored=true"
 
         try:
-            return self.rs.get(self.url+"/api/kb/products/{}".format(params)).json()
+            return self.rs.get(self.url + "/api/kb/products/{}".format(params)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to list products: {}".format(e))
 
@@ -548,6 +548,6 @@ class PatrowlHearsApi:
             params += "&monitored=true"
 
         try:
-            return self.rs.get(self.url+"/api/kb/packages/{}".format(params)).json()
+            return self.rs.get(self.url + "/api/kb/packages/{}".format(params)).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to list packages: {}".format(e))

--- a/patrowlhears4py/api.py
+++ b/patrowlhears4py/api.py
@@ -313,7 +313,7 @@ class PatrowlHearsApi:
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to toggle vendor monitoring status: {}".format(e))
 
-    def toggle_product_monitoring(self, organization_id, vendor_name, product_name, monitored):
+    def toggle_product_monitoring(self, product_id, organization_id, vendor_name, product_name, monitored):
         """
         Toggle monitoring status of a product by his name.
 
@@ -324,6 +324,7 @@ class PatrowlHearsApi:
         :rtype: json
         """
         data = {
+            'product_id': product_id,
             'monitored': monitored is True,
             'organization_id': organization_id,
             'vendor_name': vendor_name,

--- a/patrowlhears4py/api.py
+++ b/patrowlhears4py/api.py
@@ -112,7 +112,7 @@ class PatrowlHearsApi:
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to retrieve vuln stats: {}".format(e))
 
-    def search_vulns(self, cveid=None, monitored=None, search=None, vendor_name=None, product_name=None, product_version=None, cpe=None, page=1, limit=10):
+    def search_vulns(self, cveid=None, monitored=None, search=None, vendor_name=None, product_name=None, product_version=None, cpe=None, score=None, updated_since=None, sorted_by=None, page=1, limit=10):
         """
         Get vulnerabilities from criterias.
 
@@ -142,6 +142,26 @@ class PatrowlHearsApi:
             filters += "&product_version={}".format(str(product_version).lower())
         if cpe is not None and cpe != '':
             filters += "&cpe={}".format(str(cpe).lower())
+        if score is not None and score != '':
+            filters += "&score__gte={}".format(score)
+        if updated_since is not None and updated_since != '':
+            filters += "&updated_at__gte={}".format(updated_since)
+        if sorted_by is not None and sorted_by in [
+            'id', '-id',
+            'cveid', '-cveid',
+            'cvss', '-cvss',
+            'cvss3', '-cvss3',
+            'score', '-score',
+            'exploit_count', '-exploit_count',
+            'summary', '-summary',
+            'monitored', '-monitore',
+            'published', '-published',
+            'updated_at', '-updated_at',
+            'is_exploitable', '-is_exploitable',
+            'is_in_the_news', '-is_in_the_news',
+            'is_confirmed', '-is_confirmed'
+        ]:
+            filters += "&sorted_by={}".format(str(sorted_by).lower())
 
         try:
             return self.rs.get(self.url + "/api/vulns/{}".format(filters)).json()

--- a/patrowlhears4py/api.py
+++ b/patrowlhears4py/api.py
@@ -524,9 +524,9 @@ class PatrowlHearsApi:
             params += "&monitored=true"
 
         try:
-            return self.rs.get(self.url+"/api/kb/vendors/{}".format(params)).json()
+            return self.rs.get(self.url+"/api/kb/products/{}".format(params)).json()
         except requests.exceptions.RequestException as e:
-            raise PatrowlHearsException("Unable to list vendors: {}".format(e))
+            raise PatrowlHearsException("Unable to list products: {}".format(e))
 
     def get_packages(self, type=None, name=None, monitored=False, page=1, limit=10):
         """

--- a/patrowlhears4py/api.py
+++ b/patrowlhears4py/api.py
@@ -228,7 +228,7 @@ class PatrowlHearsApi:
                 data.update({'references': vuln['references']})
 
         try:
-            return self.rs.post(self.url+"/api/vulns/add", data).json()
+            return self.rs.post(self.url+"/api/vulns/add", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to add vuln: {}".format(e))
 
@@ -309,7 +309,7 @@ class PatrowlHearsApi:
             'vendor_name': vendor_name
         }
         try:
-            return self.rs.post(self.url+"/api/monitor/vendor/toggle", data).json()
+            return self.rs.post(self.url+"/api/monitor/vendor/toggle", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to toggle vendor monitoring status: {}".format(e))
 
@@ -331,7 +331,7 @@ class PatrowlHearsApi:
             'product_name': product_name
         }
         try:
-            return self.rs.post(self.url+"/api/monitor/product/toggle", data).json()
+            return self.rs.post(self.url+"/api/monitor/product/toggle", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to toggle product monitoring status: {}".format(e))
 
@@ -350,7 +350,7 @@ class PatrowlHearsApi:
             'package_id': package_id
         }
         try:
-            return self.rs.post(self.url+"/api/monitor/package/toggle", data).json()
+            return self.rs.post(self.url+"/api/monitor/package/toggle", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to toggle vendor monitoring status: {}".format(e))
 
@@ -369,7 +369,7 @@ class PatrowlHearsApi:
             'vuln_id': vuln_id
         }
         try:
-            return self.rs.post(self.url+"/api/vulns/{}/toggle".format(vuln_id), data).json()
+            return self.rs.post(self.url+"/api/vulns/{}/toggle".format(vuln_id), json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to toggle vuln monitoring status: {}".format(e))
 
@@ -465,7 +465,7 @@ class PatrowlHearsApi:
                 data.update({'maturity': exploit['maturity']})
 
         try:
-            return self.rs.post(self.url+"/api/data/submit", data).json()
+            return self.rs.post(self.url+"/api/data/submit", json=data).json()
         except requests.exceptions.RequestException as e:
             raise PatrowlHearsException("Unable to retrieve data: {}".format(e))
 


### PR DESCRIPTION
### What's changed

- Fix #1 
	- Add a new mandatory parameter `product_id`
	- Send a JSON-encoded POST request
- Fix #2 
	- Use the correct API (`/api/kb/products/` instead of `/api/kb/vendors/`)
- Some changes to respect Flake8
- Add `score` and `updated_since` parameter in `search_vuln`